### PR TITLE
Increase max repositories from 30 to 1000

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -50,7 +50,7 @@ ready(start);
 
 
 function fetchRepos(username, widgetId) {
-    var url = "https://api.github.com/users/" + username + "/repos";
+    var url = "https://api.github.com/users/" + username + "/repos?per_page=1000";
     getJSON(url, function(response) {
         updateRepoDetails(topRepos(response), widgetId);
         updateLastPush(lastPushedDay(response), widgetId);


### PR DESCRIPTION
This allows `topRepos` to give more complete results when a user has
many repositories.  A better approach would use pagination.