### PR TITLE
remove extra hr tag

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -36,7 +36,7 @@ function start() {
     for (var i = 0; i < widgets.length; i++) {
         var parentNode = widgets[i];
         parentNode.setAttribute("id", "widget" + i);
-        appendToWidget("#widget" + i, "div", "", '<div class="gh-widget-container"><div class="gh-widget-item gh-widget-photo"></div><div class="gh-widget-item gh-widget-personal-details"></div></div><div class="gh-widget-container gh-widget-stats"></div><hr class="gh-widget-hr"><div class="gh-widget-container"><div class="gh-widget-item gh-widget-heading">Top repositories</div></div><div class="gh-widget-repositories"></div><div class="gh-widget-container"><div class="gh-widget-item gh-widget-follow"></div><div class="gh-widget-item gh-widget-active-time"></div></div>')
+        appendToWidget("#widget" + i, "div", "", '<div class="gh-widget-container"><div class="gh-widget-item gh-widget-photo"></div><div class="gh-widget-item gh-widget-personal-details"></div></div><div class="gh-widget-container gh-widget-stats"></div><div class="gh-widget-container"><div class="gh-widget-item gh-widget-heading">Top repositories</div></div><div class="gh-widget-repositories"></div><div class="gh-widget-container"><div class="gh-widget-item gh-widget-follow"></div><div class="gh-widget-item gh-widget-active-time"></div></div>')
 
         var username = parentNode.dataset.username;
 


### PR DESCRIPTION
Fixes #
remove extra hr tag `<hr class="gh-widget-hr">` for causing two empty blocks shown in image below
![CleanShot 2020-06-19 at 02 51 35](https://user-images.githubusercontent.com/22731254/85093815-e5479900-b1f5-11ea-9ca1-121289f475a3.png)


